### PR TITLE
logging stack traces

### DIFF
--- a/lib/logule.js
+++ b/lib/logule.js
@@ -161,6 +161,11 @@ Logger.prototype.muteOnly = function () {
   return this;
 };
 
+// Helper for logging stack traces, uses log level error
+Logger.prototype.stack = function (err) {
+  this.error(err instanceof Error ? err.stack : new Error(err).stack);
+};
+
 // Prevent leaky prototype hacks via l.constructor.prototype
 Object.freeze(Logger.prototype);
 


### PR DESCRIPTION
Just found myself doing this everywhere:

```javascript
log.error(err instanceof Error ? err.stack : new Error(err).stack);
```

you know to guard against the guy who just throws a string :p
thought it might be useful to have a helper for this...