### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ log.unmuteOnly(); // unmuteOnly nothing === mute everything
 ## Configuration
 Configuration of colors, style, date formatting, transports, setting mutability and global suppression levels are done via config files. The [default configuration file](https://github.com/clux/logule/blob/master/.logule.json) results in output looking like the images herein.
 
-Configs are located via the [confortable](https://github.com/clux/confortable) module. This module performs priority based config searches. In particular, it is used here with the following path priorities:
+Configs are located via the [comfortable](https://github.com/clux/comfortable) module. This module performs priority based config searches. In particular, it is used here with the following path priorities:
 
 - 1. execution directory
 - 2a). if (`execDir` outside `$HOME`) `$HOME`


### PR DESCRIPTION
@clux, I've corrected a typographical error in the documentation of the [logule](https://github.com/clux/logule) project. Specifically, I've changed confortable to comfortable. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
